### PR TITLE
Bump test timeout

### DIFF
--- a/stm_test.go
+++ b/stm_test.go
@@ -27,7 +27,7 @@ func TestDecrement(t *testing.T) {
 	}()
 	select {
 	case <-done:
-	case <-time.After(time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("decrement did not complete in time")
 	}
 }


### PR DESCRIPTION
`TestDecrement` has a 1s timeout and the test itself takes around 1s on my computer, so it's pretty flaky:

<img width="398" alt="CleanShot 2022-06-07 at 22 38 17@2x" src="https://user-images.githubusercontent.com/1387653/172532894-7e1194e8-1386-4a74-ba66-b89b3b59e755.png">

This bumps the timeout to 10s so it's much more reliable.